### PR TITLE
Fixed YER Crash

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1824,9 +1824,14 @@ void CTFPlayer::GiveDefaultItems()
 				// Not allowed
 				if ( pWeapon == GetActiveWeapon() )
 					pWeapon->Holster();
+				CTFWeaponBase* pWeapon_PDA = Weapon_GetWeaponByType(TF_WPN_TYPE_PDA);
 
-				Weapon_Detach( Weapon_GetWeaponByType( TF_WPN_TYPE_PDA ) );
-				UTIL_Remove( Weapon_GetWeaponByType( TF_WPN_TYPE_PDA ) );
+				//Only do this if the PDA doesn't Return null.
+				if (pWeapon_PDA != NULL)
+				{
+					Weapon_Detach(pWeapon_PDA);
+					UTIL_Remove(pWeapon_PDA);
+				}
 				continue;
 			}
 
@@ -3838,6 +3843,7 @@ void CTFPlayer::HandleCommand_JoinClass( const char *pClassName )
 			return;
 		}
 
+		// Add the player to the join Queue
 		// Add the player to the join Queue
 		if ( TFGameRules()->IsInArenaMode() && tf_arena_use_queue.GetBool() && GetTeamNumber() <= LAST_SHARED_TEAM )
 		{

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -3844,7 +3844,6 @@ void CTFPlayer::HandleCommand_JoinClass( const char *pClassName )
 		}
 
 		// Add the player to the join Queue
-		// Add the player to the join Queue
 		if ( TFGameRules()->IsInArenaMode() && tf_arena_use_queue.GetBool() && GetTeamNumber() <= LAST_SHARED_TEAM )
 		{
 			TFGameRules()->AddPlayerToQueue( this );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2245,16 +2245,10 @@ bool CTFWeaponBase::IsPenetrating(void)
 // Purpose: Used to calculate if a weapon causes decapitations.
 //-----------------------------------------------------------------------------
 bool CTFWeaponBase::CanDecapitate( void )
-{
-	if (GetCustomDamageType() == TF_DMG_CUSTOM_DECAPITATION_BOSS || 
-		GetCustomDamageType() == TF_DMG_CUSTOM_MERASMUS_DECAPITATION ||
-		GetCustomDamageType() == TF_DMG_CUSTOM_TAUNTATK_BARBARIAN_SWING || 
-		GetCustomDamageType() == TF_DMG_CUSTOM_DECAPITATION )
-		 return true;
-			 
+{			 
 	int nDecapitateType = 0;
 	CALL_ATTRIB_HOOK_INT(nDecapitateType, decapitate_type);
-	return ( nDecapitateType != 0 && ( GetCustomDamageType() ==  TF_DMG_CUSTOM_HEADSHOT ) );
+	return ( nDecapitateType != 0 );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2245,10 +2245,16 @@ bool CTFWeaponBase::IsPenetrating(void)
 // Purpose: Used to calculate if a weapon causes decapitations.
 //-----------------------------------------------------------------------------
 bool CTFWeaponBase::CanDecapitate( void )
-{			 
+{
+	if (GetCustomDamageType() == TF_DMG_CUSTOM_DECAPITATION_BOSS || 
+		GetCustomDamageType() == TF_DMG_CUSTOM_MERASMUS_DECAPITATION ||
+		GetCustomDamageType() == TF_DMG_CUSTOM_TAUNTATK_BARBARIAN_SWING || 
+		GetCustomDamageType() == TF_DMG_CUSTOM_DECAPITATION )
+		 return true;
+			 
 	int nDecapitateType = 0;
 	CALL_ATTRIB_HOOK_INT(nDecapitateType, decapitate_type);
-	return ( nDecapitateType != 0 );
+	return ( nDecapitateType != 0 && ( GetCustomDamageType() ==  TF_DMG_CUSTOM_HEADSHOT ) );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This Fixes the YER crash, caused by the function to remove the PDA is called multiple times, and doesn't check if it is Null first before trying to detach it and remove it.